### PR TITLE
Watch a folder and move attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## Binary File Manager Plugin
+## Obsidian Binary File Manager
+
+![GitHub manifest version (path)](https://img.shields.io/github/manifest-json/v/willjasen/obsidian-binary-file-manager-plugin)
 
 This plugin detects new binary files in the vault and creates markdown files with metadata. The new binary file can then be moved into a different directory, like attachments.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Binary File Manager Plugin
 
-This plugin detects new binary files in the vault and create markdown files with metadata.
+This plugin detects new binary files in the vault and creates markdown files with metadata. The new binary file can then be moved into a different directory, like attachments.
 
 By using metadata files, you can take advantage of the rich functionality provied by Obsidian such as
-- full text search, 
-- tags and aliases, 
+- full text search,
+- tags and aliases,
 - internal links, and so on.
 
 For example, if you add tags to the metadata of an image file, then you can indirectly access the image file by tag-searching (and following an internal link in the metadata).

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
 	"description": "Detects new binary files in the vault and create markdown files with metadata.",
 	"author": "qawatake, matthewturk, willjasen",
 	"authorUrl": "https://github.com/willjasen/obsidian-binary-file-manager-plugin",
-	"isDesktopOnly": false
+	"isDesktopOnly": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
 	"id": "obsidian-binary-file-manager-plugin",
 	"name": "Binary File Manager",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"minAppVersion": "0.12.0",
 	"description": "Detects new binary files in the vault and create markdown files with metadata.",
-	"author": "qawatake",
-	"authorUrl": "https://github.com/qawatake/obsidian-binary-file-manager-plugin",
+	"author": "qawatake, matthewturk, willjasen",
+	"authorUrl": "https://github.com/willjasen/obsidian-binary-file-manager-plugin",
 	"isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-binary-file-manager-plugin",
 	"name": "Binary File Manager",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"minAppVersion": "0.12.0",
 	"description": "Detects new binary files in the vault and create markdown files with metadata.",
 	"author": "qawatake, matthewturk, willjasen",

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
 	"description": "Detects new binary files in the vault and create markdown files with metadata.",
 	"author": "qawatake, matthewturk, willjasen",
 	"authorUrl": "https://github.com/willjasen/obsidian-binary-file-manager-plugin",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -100,19 +100,18 @@ export class MetaDataGenerator {
 
 		// process by Templater
 		const templaterPlugin = await this.getTemplaterPlugin();
+		const binaryFileName = binaryFile.basename+"."+binaryFile.extension;
 		if (!(this.plugin.settings.useTemplater && templaterPlugin)) {
 			this.app.vault.create(
 				metaDataFilePath,
 				this.plugin.formatter.format(
 					templateContent,
-					binaryFile.path,
+					(attachmentsFilePath+"/"+binaryFileName),
 					binaryFile.stat.ctime
 				)
 			);
 
 			// move binary file into attachments folder
-			let binaryFileName = binaryFile.basename+"."+binaryFile.extension;
-
 			try {
 				await this.app.fileManager.renameFile(binaryFile, (attachmentsFilePath+"/"+binaryFileName));
 			} catch (err) {

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -34,10 +34,14 @@ export class MetaDataGenerator {
 		if (!(file instanceof TFile)) {
 			return false;
 		}
+
+		let filePath = file.path.toString();
+		let folderPath = filePath.substring(0,filePath.lastIndexOf("/"));
+
 		if (
-			!file.path.startsWith(
+			!(folderPath === (
 				normalizePath(this.plugin.settings.binaryFilePath)
-			)
+			))
 		) {
 			return false;
 		}

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -115,6 +115,7 @@ export class MetaDataGenerator {
 			// move binary file into attachments folder
 			try {
 				await this.app.fileManager.renameFile(binaryFile, moveToFullFilePath);
+				new Notice(`Binary file of ${binaryFileName} has been moved.`);
 			} catch (err) {
 				alert(err);
 			}

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -65,7 +65,6 @@ export class MetaDataGenerator {
 		);
 		const metaDataFilePath = `${this.plugin.settings.folder}/${metaDataFileName}`;
 
-
 		await this.createMetaDataFile(metaDataFilePath, file as TFile);
 	}
 
@@ -91,12 +90,32 @@ export class MetaDataGenerator {
 		}
 	}
 
+	private uniquefyBinaryFileName(binaryFileName: string): string {
+		const binaryFilePath = normalizePath(
+			`${this.plugin.settings.folder}/${binaryFileName}`
+		);
+		const attachmentsFilePath = `${this.plugin.settings.attachmentsFilePath}`;
+		const attachmentFullFilePath = attachmentsFilePath+"/"+binaryFileName;
+		if (this.app.vault.getAbstractFileByPath(attachmentFullFilePath)) {
+			return `CONFLICT-${moment().format(
+				'YYYY-MM-DD-hh-mm-ss'
+			)}-${binaryFileName}`;
+		} else {
+			return binaryFileName;
+		}
+	}
+
 	private async moveBinaryFile(
     binaryFile: TFile
 	): Promise<void> {
+
+		const binaryFileName = this.uniquefyBinaryFileName(
+			binaryFile.basename+"."+binaryFile.extension
+		);
+
 		// move binary file into attachments folder
 		const attachmentsFilePath = `${this.plugin.settings.attachmentsFilePath}`;
-		const binaryFileName = binaryFile.basename+"."+binaryFile.extension;
+		//const binaryFileName = binaryFile.basename+"."+binaryFile.extension;
 		const fullFilePath = attachmentsFilePath+"/"+binaryFileName;
 		try {
 			await this.app.fileManager.renameFile(binaryFile, fullFilePath);

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -101,19 +101,20 @@ export class MetaDataGenerator {
 		// process by Templater
 		const templaterPlugin = await this.getTemplaterPlugin();
 		const binaryFileName = binaryFile.basename+"."+binaryFile.extension;
+		const moveToFullFilePath = attachmentsFilePath+"/"+binaryFileName;
 		if (!(this.plugin.settings.useTemplater && templaterPlugin)) {
 			this.app.vault.create(
 				metaDataFilePath,
 				this.plugin.formatter.format(
 					templateContent,
-					(attachmentsFilePath+"/"+binaryFileName),
+					moveToFullFilePath,
 					binaryFile.stat.ctime
 				)
 			);
 
 			// move binary file into attachments folder
 			try {
-				await this.app.fileManager.renameFile(binaryFile, (attachmentsFilePath+"/"+binaryFileName));
+				await this.app.fileManager.renameFile(binaryFile, moveToFullFilePath);
 			} catch (err) {
 				alert(err);
 			}

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -34,6 +34,13 @@ export class MetaDataGenerator {
 		if (!(file instanceof TFile)) {
 			return false;
 		}
+		if (
+			!file.path.startsWith(
+				normalizePath(this.plugin.settings.binaryFilePath)
+			)
+		) {
+			return false;
+		}
 
 		const matchedExtension =
 			this.plugin.fileExtensionManager.getExtensionMatchedBest(file.name);

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -132,6 +132,20 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 					});
 			});
 
+			new Setting(containerEl)
+				.setName('Attachments folder')
+				.setDesc('Binary files will be moved here after metadata creation')
+				.addSearch((component) => {
+					new FolderSuggest(this.app, component.inputEl);
+					component
+						.setPlaceholder('Example: folder1/folder2')
+						.setValue(this.plugin.settings.attachmentsFilePath)
+						.onChange((newFolder) => {
+							this.plugin.settings.attachmentsFilePath = newFolder;
+							this.plugin.saveSettings();
+						});
+				});
+
 		let extensionToBeAdded: string;
 		new Setting(containerEl)
 			.setName('Extension to be watched')

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -68,7 +68,7 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('New file location')
+			.setName('Metadata location')
 			.setDesc('New metadata file will be placed here')
 			.addSearch((component) => {
 				new FolderSuggest(this.app, component.inputEl);

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -40,6 +40,34 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName('Watched folder')
+			.setDesc('Only this folder will be watched for new files (subfolders will not be watched)')
+			.addSearch((component) => {
+				new FolderSuggest(this.app, component.inputEl);
+				component
+					.setPlaceholder('Example: folder1/folder2')
+					.setValue(this.plugin.settings.binaryFilePath)
+					.onChange((newFolder) => {
+						this.plugin.settings.binaryFilePath = newFolder;
+						this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(containerEl)
+			.setName('Attachments folder')
+			.setDesc('Binary files will be moved here after metadata creation')
+			.addSearch((component) => {
+				new FolderSuggest(this.app, component.inputEl);
+				component
+					.setPlaceholder('Example: folder1/folder2')
+					.setValue(this.plugin.settings.attachmentsFilePath)
+					.onChange((newFolder) => {
+						this.plugin.settings.attachmentsFilePath = newFolder;
+						this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(containerEl)
 			.setName('New file location')
 			.setDesc('New metadata file will be placed here')
 			.addSearch((component) => {
@@ -117,34 +145,6 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 						this.plugin.saveSettings();
 					});
 			});
-
-		new Setting(containerEl)
-			.setName('Watched folder')
-			.setDesc('Only this folder will be watched for new files (subfolders will not be watched)')
-			.addSearch((component) => {
-				new FolderSuggest(this.app, component.inputEl);
-				component
-					.setPlaceholder('Example: folder1/folder2')
-					.setValue(this.plugin.settings.binaryFilePath)
-					.onChange((newFolder) => {
-						this.plugin.settings.binaryFilePath = newFolder;
-						this.plugin.saveSettings();
-					});
-			});
-
-			new Setting(containerEl)
-				.setName('Attachments folder')
-				.setDesc('Binary files will be moved here after metadata creation')
-				.addSearch((component) => {
-					new FolderSuggest(this.app, component.inputEl);
-					component
-						.setPlaceholder('Example: folder1/folder2')
-						.setValue(this.plugin.settings.attachmentsFilePath)
-						.onChange((newFolder) => {
-							this.plugin.settings.attachmentsFilePath = newFolder;
-							this.plugin.saveSettings();
-						});
-				});
 
 		let extensionToBeAdded: string;
 		new Setting(containerEl)

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -119,8 +119,8 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Binary file parent folder')
-			.setDesc('Only this folder will be watched for new files')
+			.setName('Watched folder')
+			.setDesc('Only this folder will be watched for new files (subfolders will not be watched)')
 			.addSearch((component) => {
 				new FolderSuggest(this.app, component.inputEl);
 				component

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -118,6 +118,20 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 					});
 			});
 
+		new Setting(containerEl)
+			.setName('Binary file parent folder')
+			.setDesc('Only this folder will be watched for new files')
+			.addSearch((component) => {
+				new FolderSuggest(this.app, component.inputEl);
+				component
+					.setPlaceholder('Example: folder1/folder2')
+					.setValue(this.plugin.settings.binaryFilePath)
+					.onChange((newFolder) => {
+						this.plugin.settings.binaryFilePath = newFolder;
+						this.plugin.saveSettings();
+					});
+			});
+
 		let extensionToBeAdded: string;
 		new Setting(containerEl)
 			.setName('Extension to be watched')

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, TAbstractFile, TFile } from 'obsidian';
+import { FileManager, Notice, Plugin, TAbstractFile, TFile } from 'obsidian';
 import { Formatter } from 'Formatter';
 import { BinaryFileManagerSettingTab } from 'Setting';
 import { FileExtensionManager } from 'Extension';
@@ -10,6 +10,7 @@ interface BinaryFileManagerSettings {
 	extensions: string[];
 	folder: string;
 	binaryFilePath: string;
+	attachmentsFilePath: string;
 	filenameFormat: string;
 	templatePath: string;
 	useTemplater: boolean;
@@ -38,6 +39,7 @@ const DEFAULT_SETTINGS: BinaryFileManagerSettings = {
 	],
 	folder: '/',
 	binaryFilePath: '/',
+	attachmentsFilePath: '/',
 	filenameFormat: 'INFO_{{NAME}}_{{EXTENSION:UP}}',
 	templatePath: '',
 	useTemplater: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ interface BinaryFileManagerSettings {
 	autoDetection: boolean;
 	extensions: string[];
 	folder: string;
+	binaryFilePath: string;
 	filenameFormat: string;
 	templatePath: string;
 	useTemplater: boolean;
@@ -36,6 +37,7 @@ const DEFAULT_SETTINGS: BinaryFileManagerSettings = {
 		'pdf',
 	],
 	folder: '/',
+	binaryFilePath: '/',
 	filenameFormat: 'INFO_{{NAME}}_{{EXTENSION:UP}}',
 	templatePath: '',
 	useTemplater: false,


### PR DESCRIPTION
- only files placed into the watched folder will generate metadata (subfolders of the watched folder are not watched)
- binary files that are found are moved into the attachments folder after metadata creation
- updated plugin gui so that things make a little more sense (at least to me)